### PR TITLE
Fix err invalid callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const clasps = JSON.parse(fs.readFileSync(MULTICLASP_FILENAME, UTF_8));
               console.log('stdout:', stdout);
           } catch (e) {
               console.error(e); // should contain code (exit code) and signal (that caused the termination).
+              return false;
           }
       }
 


### PR DESCRIPTION
Hello @steplica 
I was receiving the following error doing a simple multi-clasp. 
The writeFile() needed a callback.
I also used the awaits to wait for the execution of the "clasp push" or the writeFile() to finish before doing the next operation.

> multi-clasp push

node:internal/validators:215
    throw new ERR_INVALID_CALLBACK(callback);
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received 'utf8'
    at maybeCallback (node:fs:174:3)
    at Object.writeFile (node:fs:2091:14)
    at /home/workspace/FAO/fao-crop-calendar/fao-crop-calendar-gas-utility/node_modules/multi-clasp/index.js:17:10
    at Array.forEach (<anonymous>)
    at Object.push (/home/workspace/FAO/fao-crop-calendar/fao-crop-calendar-gas-utility/node_modules/multi-clasp/index.js:16:12)
    at Object.<anonymous> (/home/workspace/FAO/fao-crop-calendar/fao-crop-calendar-gas-utility/node_modules/multi-clasp/index.js:28:16)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12) {
  code: 'ERR_INVALID_CALLBACK'
}

------------Environment information
Node: 16.5.0
OS: Linux
My project devDependencies:
  "devDependencies": {
    "@google/clasp": "^2.3.0",
    "@types/google-apps-script": "^1.0.37",
    "cpy-cli": "^3.1.1",
    "multi-clasp": "^1.0.0"
  }



Let me know if you need more information.

Cheers!
Fabrizio